### PR TITLE
Re-enabling passing tests

### DIFF
--- a/spec/integration/cluster/worker-allocation-tests.js
+++ b/spec/integration/cluster/worker-allocation-tests.js
@@ -49,15 +49,15 @@ module.exports = function() {
             workersTest(1, 1, 1000, done);
         });
 
-        xit('Job should allocate with 5 workers.', function(done) {
+        it('Job should allocate with 5 workers.', function(done) {
             workersTest(5, 5, 10000, done)
         });
 
-        xit('Job should run with 14 out of requested 20 workers.', function(done) {
+        it('Job should run with 14 out of requested 20 workers.', function(done) {
             workersTest(20, 14, 10000, done)
         });
 
-        xit('Job should scale from 14 to 20 workers.', function(done) {
+        it('Job should scale from 14 to 20 workers.', function(done) {
             // Test cluster has 16 workers total.
             // 1 is consumed by the cluster_master. 1 by the slicer.
             // So the job should consume 14 to start.

--- a/spec/integration/data/reindex-tests.js
+++ b/spec/integration/data/reindex-tests.js
@@ -81,7 +81,7 @@ module.exports = function() {
         });
 
 
-        xit('should reindex data 10 times', function(done) {
+        it('should reindex data 10 times', function(done) {
             var job_spec = _.cloneDeep(require('../../fixtures/jobs/reindex.json'));
             job_spec.operations[1].index = 'test-reindex-10times';
 

--- a/spec/integration/suite-spec.js
+++ b/spec/integration/suite-spec.js
@@ -37,8 +37,8 @@ describe('teraslice - ', function() {
     }
 
     suites.push(require('./cluster/worker-allocation-tests')());
-    //suites.push(require('./cluster/state-tests')());
-    //suites.push(require('./data/reindex-tests')());
+    suites.push(require('./cluster/state-tests')());
+    suites.push(require('./data/reindex-tests')());
     //suites.push(require('./validation/job-validation-tests')());
 
 });


### PR DESCRIPTION
I am not sure why these were disabled.  @kstaken had them enabled on
his working copy.  I am re-enabling them on the assumption that they
were disabled as an oversight.  I know that these tests PASS, but I don't
know that they are implemented correctly, still working on understanding
things well enough to confirm that manually.

@kstaken verbally indicated that the `job-validation-tests` were not yet
complete, so they are still omitted.
