### PR TITLE
Initial test case for elasticsearch_bulk

### DIFF
--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -26,10 +26,22 @@ var generator = {
 
 setup.dockerUp('teracluster__jobs')
     .then(function(connections) {
+
         function generate(count) {
             generator.name = 'Data Generator ' + count;
             generator.operations[0].size = count;
             generator.operations[1].index = 'example-logs-' + count;
+            return teraslice.jobs.submit(generator)
+        }
+
+        function idGenerate(count, letter) {
+            generator.name = 'Data Generator ' + count;
+            generator.operations[0].size = count;
+            generator.operations[0].set_id = 'hexadecimal';
+            generator.operations[0].id_start_key = letter;
+            generator.operations[1].index = 'example-hexadecimal-logs';
+            generator.operations[1].id_field = 'id';
+
             return teraslice.jobs.submit(generator)
         }
 
@@ -40,7 +52,9 @@ setup.dockerUp('teracluster__jobs')
         return Promise.all([
             generate(10),
             generate(1000),
-            generate(10000)
+            generate(10000),
+            idGenerate(5000, 'd'),
+            idGenerate(5000, '3')
         ])
     })
     .map(function(job) {

--- a/spec/fixtures/jobs/id.json
+++ b/spec/fixtures/jobs/id.json
@@ -1,0 +1,26 @@
+
+{
+  "name": "ID_Reindex",
+  "lifecycle": "once",
+  "analytics": true,
+  "slicers": 2,
+  "workers": 4,
+  "operations": [
+    {
+      "_op": "id_reader",
+      "index": "example-logs-10000",
+      "type": "events",
+      "size": 1000,
+      "key_type": "base64url"
+    },
+    {
+      "_op": "elasticsearch_index_selector",
+      "index": "test-id_reindex-10000",
+      "type": "events"
+    },
+    {
+      "_op": "elasticsearch_bulk",
+      "size": 50000
+    }
+  ]
+}

--- a/spec/fixtures/jobs/multisend.json
+++ b/spec/fixtures/jobs/multisend.json
@@ -1,0 +1,33 @@
+{
+    "name": "Multisend Test",
+    "workers": 1,
+    "lifecycle": "once",
+
+    "operations": [
+        {
+            "_op": "elasticsearch_reader",
+            "index": "example-logs-10000",
+            "full_response": true,
+            "date_field_name": "created",
+            "type": "change",
+            "size": 500
+        },
+        {
+            "_op": "elasticsearch_index_selector",
+            "index": "multisend-10000",
+            "preserve_id": true,
+            "type": "change"
+        },
+        {
+            "_op": "elasticsearch_bulk",
+            "multisend_index_append": false,
+            "size": 100,
+            "multisend": true,
+            "connection_map": {
+                "A": "default",
+                "B": "default",
+                "*": "default"
+            }
+        }
+    ]
+}

--- a/spec/integration/data/elasticsearch_bulk-tests.js
+++ b/spec/integration/data/elasticsearch_bulk-tests.js
@@ -1,0 +1,40 @@
+'use strict';
+
+var Promise = require('bluebird');
+var _ = require('lodash');
+
+module.exports = function() {
+    var teraslice, es_client, es_helper;
+
+    describe('elasticsearch_bulk', function() {
+
+        it('multisend should generate correct number of docs', function(done) {
+            var job_spec = _.cloneDeep(require('../../fixtures/jobs/multisend.json'));
+            job_spec.operations[1].index = 'test-multisend-10000';
+
+            teraslice.jobs.submit(job_spec)
+                .then(function(job) {
+                    expect(job).toBeDefined();
+                    expect(job.id()).toBeDefined();
+
+                    // The job may run for a while so we have to wait for it to finish.
+                    return job.waitForStatus('completed');
+                })
+                .then(function() {
+                    return es_helper.documentCountForIndex('test-multisend-10000')
+                        .then(function(stats) {
+                            expect(stats.count).toBe(10000);
+                            expect(stats.deleted).toBe(0);
+                        });
+                })
+                .catch(fail)
+                .finally(done)
+        });
+    });
+
+    return function(connections) {
+        es_client = connections.es_client;
+        teraslice = connections.teraslice_client;
+        es_helper = require('../helpers/es_helper')(es_client);
+    }
+};

--- a/spec/integration/data/id_slicer.js
+++ b/spec/integration/data/id_slicer.js
@@ -1,0 +1,140 @@
+'use strict';
+
+var _ = require('lodash');
+
+module.exports = function() {
+    var teraslice, es_client, es_helper;
+
+    describe('reindex', function() {
+
+        it('should reindex data by ids', function(done) {
+            var job_spec = _.cloneDeep(require('../../fixtures/jobs/id.json'));
+            job_spec.operations[1].index = "test-id_reindex-10000";
+
+            teraslice.jobs.submit(job_spec)
+                .then(function(job) {
+                    expect(job).toBeDefined();
+                    expect(job.id()).toBeDefined();
+
+                    // The job may run for a while so we have to wait for it to finish.
+                    return job.waitForStatus('completed');
+                })
+                .then(function() {
+                    return es_helper.documentCountForIndex('test-id_reindex-10000')
+                        .then(function(stats) {
+                            expect(stats.count).toBe(10000);
+                            expect(stats.deleted).toBe(0);
+                        });
+                })
+                .catch(fail)
+                .finally(done)
+        });
+
+    });
+
+    it('should reindex data by hexadecimal ids', function(done) {
+        var job_spec = _.cloneDeep(require('../../fixtures/jobs/id.json'));
+        job_spec.operations[0].key_type = 'hexadecimal';
+        job_spec.operations[0].index = 'example-hexadecimal-logs';
+        job_spec.operations[1].index = "test-hexadecimal-logs";
+
+        teraslice.jobs.submit(job_spec)
+            .then(function(job) {
+                expect(job).toBeDefined();
+                expect(job.id()).toBeDefined();
+
+                // The job may run for a while so we have to wait for it to finish.
+                return job.waitForStatus('completed');
+            })
+            .then(function() {
+                return es_helper.documentCountForIndex('test-hexadecimal-logs')
+                    .then(function(stats) {
+                        expect(stats.count).toBe(10000);
+                        expect(stats.deleted).toBe(0);
+                    });
+            })
+            .catch(fail)
+            .finally(done)
+    });
+
+    it('will only search on key_range', function(done) {
+        var job_spec = _.cloneDeep(require('../../fixtures/jobs/id.json'));
+        job_spec.operations[0].key_type = 'hexadecimal';
+        job_spec.operations[0].key_range = ['a', 'b', 'c', 'd', 'e'];
+
+        job_spec.operations[0].index = 'example-hexadecimal-logs';
+        job_spec.operations[1].index = 'test-keyrange-logs';
+
+        teraslice.jobs.submit(job_spec)
+            .then(function(job) {
+                expect(job).toBeDefined();
+                expect(job.id()).toBeDefined();
+
+                // The job may run for a while so we have to wait for it to finish.
+                return job.waitForStatus('completed');
+            })
+            .then(function() {
+                return es_helper.documentCountForIndex('test-keyrange-logs')
+                    .then(function(stats) {
+                        expect(stats.count).toBe(5000);
+                        expect(stats.deleted).toBe(0);
+                    });
+            })
+            .catch(fail)
+            .finally(done)
+    });
+
+    it('id_reader should complete after stopping and restarting', function(done) {
+        var job_spec = _.cloneDeep(require('../../fixtures/jobs/id.json'));
+        // Job needs to be able to run long enough to cycle
+        job_spec.operations[1].index = "test-id_reindex-lifecycle-10000";
+
+        teraslice.jobs.submit(job_spec)
+            .then(function(job) {
+                expect(job.id()).toBeDefined();
+
+                // The job may run for a while so we have to wait for it to finish.
+                return job.waitForStatus('running')
+                    .then(function() {
+                        return job.pause();
+                    })
+                    .then(function() {
+                        return job.waitForStatus('paused');
+                    })
+                    .then(function() {
+                        return job.resume();
+                    })
+                    .then(function() {
+                        return job.waitForStatus('running');
+                    })
+                    .then(function() {
+                        return job.stop();
+                    })
+                    .then(function() {
+                        return job.waitForStatus('stopped');
+                    })
+                    .then(function() {
+                        return job.recover();
+                    })
+                    .then(function() {
+                        return job.waitForStatus('completed');
+                    })
+                    .then(function() {
+                        return es_helper.documentCountForIndex("test-id_reindex-lifecycle-10000")
+                            .then(function(stats) {
+                                expect(stats.count).toBe(10000);
+                                expect(stats.deleted).toBe(0);
+                            });
+                    });
+            })
+            .catch(fail)
+            .finally(done);
+    });
+
+
+    return function(connections) {
+        es_client = connections.es_client;
+        teraslice = connections.teraslice_client;
+        es_helper = require('../helpers/es_helper')(es_client);
+    }
+};

--- a/spec/integration/suite-spec.js
+++ b/spec/integration/suite-spec.js
@@ -36,6 +36,7 @@ describe('teraslice - ', function() {
         })
     }
 
+
     suites.push(require('./data/id_slicer')());
     suites.push(require('./data/elasticsearch_bulk-tests')());
     suites.push(require('./cluster/worker-allocation-tests')());

--- a/spec/integration/suite-spec.js
+++ b/spec/integration/suite-spec.js
@@ -36,9 +36,10 @@ describe('teraslice - ', function() {
         })
     }
 
+    suites.push(require('./data/id_slicer')());
     suites.push(require('./cluster/worker-allocation-tests')());
-    //suites.push(require('./cluster/state-tests')());
-    //suites.push(require('./data/reindex-tests')());
-    //suites.push(require('./validation/job-validation-tests')());
+    suites.push(require('./cluster/state-tests')());
+    suites.push(require('./data/reindex-tests')());
+    suites.push(require('./validation/job-validation-tests')());
 
 });

--- a/spec/integration/suite-spec.js
+++ b/spec/integration/suite-spec.js
@@ -37,9 +37,9 @@ describe('teraslice - ', function() {
     }
 
     suites.push(require('./data/id_slicer')());
+    suites.push(require('./data/elasticsearch_bulk-tests')());
     suites.push(require('./cluster/worker-allocation-tests')());
     suites.push(require('./cluster/state-tests')());
     suites.push(require('./data/reindex-tests')());
     suites.push(require('./validation/job-validation-tests')());
-
 });


### PR DESCRIPTION
Initial test just copies a 10,000 record index and passes it through a multisend bulk process. All the data still goes back into a single index but the code it goes through is the same as if there were actually multiple backend connections. The test currently fails sporadically with non-zero deleted docs when deleted docs should always be zero.