### PR TITLE
Support multiple es versions issue#9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # teraslice-integration-tests
+
 Teraslice integration test suite
 
 ## Dependencies
@@ -12,16 +13,16 @@ Teraslice integration test suite
 
 ### Building the teraslice docker image
 
-You'll need a cloned version of the teraslice repository.
+You'll need a cloned version of the Teraslice repository.
 
 ```
 cd YOUR_TERASLICE_REPO
 docker build -t=teraslice .
 ```
 
-### Prep the elasticsearch test data.
+### Prepare the Elasticsearch test data.
 
-For the tests to run there needs to be data in the elasticsearch instance. A script is used to setup several source indices that are used by the tests. The data will be stored to a docker volume attached to the test environment. This only needs to be done once as the volume will be reused as tests are run.
+For the tests to run there needs to be data in the Elasticsearch instance. A script is used to setup several source indices that are used by the tests. The data will be stored to a docker volume attached to the test environment. This only needs to be done once as the volume will be reused as tests are run.
 
 ```
 npm install
@@ -31,7 +32,7 @@ npm run setup
 ip=docker npm run setup
 ```
 
-## Running the test suite
+# Running the test suite
 
 ```
 npm test
@@ -44,6 +45,60 @@ ip=docker npm test
 from the root of the folder, `cd` into /spec and type the command below
 ```
 docker-compose logs
+```
+
+# Cleaning Up When Things Go Wrong
+
+If the test suite appears to be running with unexpected results and you suspect
+that the state of the docker containers are a factor, you can remove these
+docker containers and associated volumes with the following command:
+
+```bash
+# This will delete all docker containers who's names begin with `spec_`.
+# THIS COULD RESULT IN DATA LOSS!
+npm run docker-clean
+```
+
+# Other Elasticsearch Versions
+
+By default the tests included in this suite will run against Elasticsearch
+`2.3`. The test suite currently supports testing against the following
+Elasticsearch versions:
+
+* `1.7`
+* `2.3`
+* `2.4`
+* `5.0`
+
+To configure the suite to test against a different version issue a command of
+the following format and then run the standard setup and test tasks:
+
+```bash
+npm config set teraslice-integration-tests:esVersion <VERSION>
+```
+
+For example, to test against ES 5.0 you would type:
+
+```bash
+npm config set teraslice-integration-tests:esVersion 5.0
+npm run setup
+npm run test
+```
+
+The `esVersion` selection you make is saved in your user account, so you will
+need to change it any time you want to change the ES version you are testing
+against.  You can check the current setting with the following command:
+
+```bash
+npm config get teraslice-integration-tests:esVersion
+```
+
+If the above command returns `undefined`, it will use the default `esVersion`
+config value found in the `package.json` file (currently `2.3`).  You can revert
+to the default value with the following command:
+
+```bash
+npm config delete teraslice-integration-tests:esVersion
 ```
 
 ### Notes

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ docker containers and associated volumes with the following command:
 ```bash
 # This will delete all docker containers who's names begin with `spec_`.
 # THIS COULD RESULT IN DATA LOSS!
-npm run docker-clean
+npm run clean-docker
 ```
 
 # Other Elasticsearch Versions
@@ -99,6 +99,23 @@ to the default value with the following command:
 
 ```bash
 npm config delete teraslice-integration-tests:esVersion
+```
+
+# Testing All Supported Elasticsearch Versions
+
+The test suite can be run against ALL supported ES versions by running the
+following command
+
+```bash
+npm run test-versions
+```
+
+Some output will be printed to the screen, but much more will be stored in log
+files in the `logs/` directory.  You can look through them for details on error
+conditions.  The log directory can be removed with the following command:
+
+```bash
+npm run clean-logs
 ```
 
 ### Notes

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "node node_modules/jasmine/bin/jasmine",
+    "docker-clean": "docker kill $(docker ps -q --filter 'name=spec_\\.*'); docker rm -v $(docker ps -qa --filter 'name=spec_\\.*'); docker volume rm spec_testdata",
     "setup": "node scripts/setup.js"
   },
   "repository": {
@@ -25,10 +26,12 @@
   "dependencies": {
     "bluebird": "^3.4.0",
     "docker-compose-js": "terascope/docker-compose-js",
-    "teraslice-client-js": "terascope/teraslice-client-js",
     "elasticsearch": "^11.0.1",
     "jasmine": "^2.4.1",
     "lodash": "^4.13.1",
     "teraslice-client-js": "terascope/teraslice-client-js"
+  },
+  "config": {
+    "esVersion": 2.3
   }
 }

--- a/package.json
+++ b/package.json
@@ -5,8 +5,10 @@
   "main": "index.js",
   "scripts": {
     "test": "node node_modules/jasmine/bin/jasmine",
-    "docker-clean": "docker kill $(docker ps -q --filter 'name=spec_\\.*'); docker rm -v $(docker ps -qa --filter 'name=spec_\\.*'); docker volume rm spec_testdata",
-    "setup": "node scripts/setup.js"
+    "setup": "node scripts/setup.js",
+    "test-versions": "bash scripts/test-versions.sh",
+    "clean-docker": "docker kill $(docker ps -qa --filter 'name=spec_\\.*'); docker rm $(docker ps -qa --filter 'name=spec_\\.*'); docker volume rm spec_testdata",
+    "clean-logs": "rm -rf logs"
   },
   "repository": {
     "type": "git",

--- a/scripts/setup.js
+++ b/scripts/setup.js
@@ -1,6 +1,8 @@
 'use strict';
 
-var setup = require('../spec/integration/helpers/setup')(__dirname + '/../spec/docker-compose.yml');
+var setup = require('../spec/integration/helpers/setup')(
+    `${__dirname}/../spec/docker-compose-es${process.env.npm_package_config_esVersion}.yml`
+);
 var Promise = require('bluebird');
 
 var generator = {

--- a/scripts/test-versions.sh
+++ b/scripts/test-versions.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+versions=( 1.7 2.3 2.4 5.0 )
+
+function cleanup() {
+    docker kill $(docker ps -qa --filter 'name=spec_\.*')
+    echo "Resetting esVersion to default"
+    npm config delete teraslice-integration-tests:esVersion
+}
+
+trap cleanup SIGINT
+
+echo "Test run began at: $(date)"
+
+for version in "${versions[@]}"
+do
+    echo ""
+    echo "##############################################"
+    echo "  Running tests for Elasticsearch ${version}  "
+    echo "##############################################"
+    echo ""
+
+    dir="logs/${version}"
+    mkdir -p ${dir}
+
+    npm config set teraslice-integration-tests:esVersion ${version}
+    echo "  Running setup for version ${version}."
+    npm run setup | tee ${dir}/setup.log 2>&1
+    sleep 5
+
+    echo "  Running tests for version ${version}."
+    npm test | tee ${dir}/test.log 2>&1
+    sleep 5
+
+    docker-compose -f spec/docker-compose-es${version}.yml stop > ${dir}/docker-stop.log 2>&1
+    sleep 2
+    docker-compose -f spec/docker-compose-es${version}.yml logs > ${dir}/docker-compose.log 2>&1
+    sleep 2
+
+    echo "  Cleaning up for version ${version} at $(date)"
+    docker rm $(docker ps -qa --filter 'name=spec_.*') > ${dir}/cleanup.log 2>&1
+    docker volume rm spec_testdata >> ${dir}/cleanup.log 2>&1
+done
+
+echo "Test run completed at: $(date)"
+echo ""
+
+find logs

--- a/scripts/test-versions.sh
+++ b/scripts/test-versions.sh
@@ -10,6 +10,7 @@ function cleanup() {
 
 trap cleanup SIGINT
 
+mkdir logs
 echo "Test run began at: $(date)" | tee "logs/master.log"
 
 for version in "${versions[@]}"
@@ -25,7 +26,7 @@ do
 
     npm config set teraslice-integration-tests:esVersion ${version}
     echo "  Running setup for version ${version}." | tee -a "logs/master.log"
-    npm run setup | tee ${dir}/setup.log 2>&1
+    npm run setup | tee ${dir}/setup.log 2>&1 | tee -a "logs/master.log"
     sleep 5
 
     echo "  Running tests for version ${version}." | tee -a "logs/master.log"

--- a/scripts/test-versions.sh
+++ b/scripts/test-versions.sh
@@ -10,13 +10,13 @@ function cleanup() {
 
 trap cleanup SIGINT
 
-echo "Test run began at: $(date)"
+echo "Test run began at: $(date)" | tee "logs/master.log"
 
 for version in "${versions[@]}"
 do
     echo ""
     echo "##############################################"
-    echo "  Running tests for Elasticsearch ${version}  "
+    echo "  Running tests for Elasticsearch ${version}  " | tee -a "logs/master.log"
     echo "##############################################"
     echo ""
 
@@ -24,12 +24,12 @@ do
     mkdir -p ${dir}
 
     npm config set teraslice-integration-tests:esVersion ${version}
-    echo "  Running setup for version ${version}."
+    echo "  Running setup for version ${version}." | tee -a "logs/master.log"
     npm run setup | tee ${dir}/setup.log 2>&1
     sleep 5
 
-    echo "  Running tests for version ${version}."
-    npm test | tee ${dir}/test.log 2>&1
+    echo "  Running tests for version ${version}." | tee -a "logs/master.log"
+    npm test | tee ${dir}/test.log 2>&1 | tee -a "logs/master.log"
     sleep 5
 
     docker-compose -f spec/docker-compose-es${version}.yml stop > ${dir}/docker-stop.log 2>&1
@@ -37,12 +37,12 @@ do
     docker-compose -f spec/docker-compose-es${version}.yml logs > ${dir}/docker-compose.log 2>&1
     sleep 2
 
-    echo "  Cleaning up for version ${version} at $(date)"
+    echo "  Cleaning up for version ${version} at $(date)" | tee -a "logs/master.log"
     docker rm $(docker ps -qa --filter 'name=spec_.*') > ${dir}/cleanup.log 2>&1
     docker volume rm spec_testdata >> ${dir}/cleanup.log 2>&1
 done
 
-echo "Test run completed at: $(date)"
+echo "Test run completed at: $(date)" | tee -a "logs/master.log"
 echo ""
 
 find logs

--- a/spec/docker-compose-es1.7.yml
+++ b/spec/docker-compose-es1.7.yml
@@ -1,0 +1,33 @@
+version: '2'
+services:
+  teraslice-master:
+    image: teraslice
+    ports:
+        - "45678:45678"
+    links:
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-master.yaml
+  teraslice-worker:
+    image: teraslice
+    links:
+        - teraslice-master
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-worker.yaml
+  elasticsearch:
+    image: elasticsearch:1.7
+    ports:
+        - "49200:49200"
+        - "49300:49300"
+    volumes:
+        - testdata:/usr/share/elasticsearch/data
+        #- ./fixtures/data/es1:/usr/share/elasticsearch/data
+    environment:
+        - ES_HEAP_SIZE=2G
+    command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.port=49200 -Des.transport.tcp.port=49300 -Des.cluster.name=teraslice-integration -Des.index.number_of_replicas=0 -Dthreadpool.bulk.queue_size=2000
+volumes:
+  testdata:
+    external: false

--- a/spec/docker-compose-es2.3.yml
+++ b/spec/docker-compose-es2.3.yml
@@ -1,0 +1,33 @@
+version: '2'
+services:
+  teraslice-master:
+    image: teraslice
+    ports:
+        - "45678:45678"
+    links:
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-master.yaml
+  teraslice-worker:
+    image: teraslice
+    links:
+        - teraslice-master
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-worker.yaml
+  elasticsearch:
+    image: elasticsearch:2.3
+    ports:
+        - "49200:49200"
+        - "49300:49300"
+    volumes:
+        - testdata:/usr/share/elasticsearch/data
+        #- ./fixtures/data/es1:/usr/share/elasticsearch/data
+    environment:
+        - ES_HEAP_SIZE=2G
+    command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.port=49200 -Des.transport.tcp.port=49300 -Des.cluster.name=teraslice-integration -Des.index.number_of_replicas=0 -Dthreadpool.bulk.queue_size=2000
+volumes:
+  testdata:
+    external: false

--- a/spec/docker-compose-es2.4.yml
+++ b/spec/docker-compose-es2.4.yml
@@ -1,0 +1,33 @@
+version: '2'
+services:
+  teraslice-master:
+    image: teraslice
+    ports:
+        - "45678:45678"
+    links:
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-master.yaml
+  teraslice-worker:
+    image: teraslice
+    links:
+        - teraslice-master
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-worker.yaml
+  elasticsearch:
+    image: elasticsearch:2.4
+    ports:
+        - "49200:49200"
+        - "49300:49300"
+    volumes:
+        - testdata:/usr/share/elasticsearch/data
+        #- ./fixtures/data/es1:/usr/share/elasticsearch/data
+    environment:
+        - ES_HEAP_SIZE=2G
+    command: elasticsearch -Des.network.host=0.0.0.0 -Des.http.port=49200 -Des.transport.tcp.port=49300 -Des.cluster.name=teraslice-integration -Des.index.number_of_replicas=0 -Dthreadpool.bulk.queue_size=2000
+volumes:
+  testdata:
+    external: false

--- a/spec/docker-compose-es5.0.yml
+++ b/spec/docker-compose-es5.0.yml
@@ -1,0 +1,31 @@
+version: '2'
+services:
+  teraslice-master:
+    image: teraslice
+    ports:
+        - "45678:45678"
+    links:
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-master.yaml
+  teraslice-worker:
+    image: teraslice
+    links:
+        - teraslice-master
+        - elasticsearch
+    volumes:
+        - ./fixtures/config:/app/config
+    command: node /app/source/service.js -c /app/config/processor-worker.yaml
+  elasticsearch:
+    image: elasticsearch:5.0
+    ports:
+        - "49200:49200"
+        - "49300:49300"
+    volumes:
+        - testdata:/usr/share/elasticsearch/data
+        #- ./fixtures/data/es1:/usr/share/elasticsearch/data
+    command: elasticsearch -Enetwork.host=0.0.0.0 -Ehttp.port=49200 -Etransport.tcp.port=49300 -Ecluster.name=teraslice-integration -Ethread_pool.bulk.queue_size=2000
+volumes:
+  testdata:
+    external: false

--- a/spec/integration/suite-spec.js
+++ b/spec/integration/suite-spec.js
@@ -5,7 +5,9 @@ jasmine.DEFAULT_TIMEOUT_INTERVAL = 600000;
 
 describe('teraslice - ', function() {
 
-    var setup = require('./helpers/setup')(__dirname + '/../docker-compose.yml');
+    var setup = require('./helpers/setup')(
+        `${__dirname}/../docker-compose-es${process.env.npm_package_config_esVersion}.yml`
+    );
 
     // Whether the environment should be shutdown after the test run.
     // While developing tests it can be advantageous to set this to false


### PR DESCRIPTION
    Making the test suite run against multiple ES versions

    These changes enable the test suite to run against the following versions
    of Elasticsearch:

    * 1.7
    * 2.3
    * 2.4
    * 5.0

    The default version will be version 2.3.  Controlling which version
    of ES is used is managed by npm package configuration.  See the
    changes in README.md for details on how that works.

    refs #9